### PR TITLE
For calculating coverage, tests now mark not only their beginning, but end as well.

### DIFF
--- a/Faultify.Injection/TestCoverageInjector.cs
+++ b/Faultify.Injection/TestCoverageInjector.cs
@@ -181,8 +181,8 @@ namespace Faultify.Injection
                     Instruction endRegisterInstruction =   processor.Create(OpCodes.Call, method.Module.ImportReference(_endRegisterTestCoverage));
 
                     // Insert the method signaling the start of a test, insert at index 0.
-                    method.Body.Instructions.Insert(0, beginRegisterInstruction);
-                    method.Body.Instructions.Insert(0, entityHandleInstruction);
+                    method.Body.Instructions.Insert(0, beginRegisterInstruction); // method call
+                    method.Body.Instructions.Insert(0, entityHandleInstruction);  // its argument
 
                     // Insert the method signaling the end of the test. This needs to be insterted in place of the last instruction, which is 'ret'.
                     // The Count-1 is therefore very important, if you don't the instruction is placed after 'ret', which makes it unreachable code.

--- a/Faultify.Injection/TestCoverageInjector.cs
+++ b/Faultify.Injection/TestCoverageInjector.cs
@@ -186,7 +186,7 @@ namespace Faultify.Injection
                 method.Body.Instructions.Insert(0, entityHandleInstruction);
 
                 // Insert the method signaling the end of the test. This needs to be insterted in place of the last instruction, which is 'ret'.
-                // The Count-1 is therefore very important, if you don,t the instruction is placed after 'ret', which makes it unreachable code.
+                // The Count-1 is therefore very important, if you don't the instruction is placed after 'ret', which makes it unreachable code.
                 method.Body.Instructions.Insert(method.Body.Instructions.Count-1, endRegisterInstruction);
             }
         }


### PR DESCRIPTION
This means SetUps and any other methods invoked outside of a test are ignored.