### PR TITLE
Timeout in forloops

### DIFF
--- a/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
+++ b/Faultify.TestRunner.Dotnet/DotnetTestHostRunner.cs
@@ -69,7 +69,8 @@ namespace Faultify.TestRunner.Dotnet
                         new CancellationTokenSource(timeout).Token);
 
                     var deserializedTestResults = TestResults.Deserialize(testResultsBinary, true);
-
+                    
+                    //if test result is none(Time-out) remove all tests with exactly the same mutation on the same part in the code. Removes unnecessary tests
                     if (deserializedTestResults.Tests[0].Outcome == TestOutcome.None)
                     {
                         foreach (var variant in mutationVariants)

--- a/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.NUnit/NUnitTestHostRunner.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Faultify.MemoryTest.TestInformation;
 using Faultify.TestRunner.Logging;
 using Faultify.TestRunner.Shared;
+using Faultify.TestRunner.TestRun;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using TestResult = Faultify.TestRunner.Shared.TestResult;
@@ -28,7 +29,7 @@ namespace Faultify.TestRunner.NUnit
 
         public TestFramework TestFramework => TestFramework.NUnit;
 
-        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests)
+        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests, IList<MutationVariant> variants)
         {
             var hashedTests = new HashSet<string>(tests);
 

--- a/Faultify.TestRunner.XUnit/XUnitTestHostRunner.cs
+++ b/Faultify.TestRunner.XUnit/XUnitTestHostRunner.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Faultify.MemoryTest.TestInformation;
 using Faultify.TestRunner.Logging;
 using Faultify.TestRunner.Shared;
+using Faultify.TestRunner.TestRun;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel;
 using TestResult = Faultify.TestRunner.Shared.TestResult;
@@ -25,7 +26,7 @@ namespace Faultify.TestRunner.XUnit
 
         public TestFramework TestFramework => TestFramework.XUnit;
 
-        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests)
+        public async Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress, IEnumerable<string> tests, IList<MutationVariant> variants)
         {
             var hashedTests = new HashSet<string>(tests);
 

--- a/Faultify.TestRunner/ITestHostRunner.cs
+++ b/Faultify.TestRunner/ITestHostRunner.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Faultify.TestRunner.Logging;
 using Faultify.TestRunner.Shared;
+using Faultify.TestRunner.TestRun;
 
 namespace Faultify.TestRunner
 {
@@ -22,7 +23,7 @@ namespace Faultify.TestRunner
         /// <param name="tests"></param>
         /// <returns></returns>
         Task<TestResults> RunTests(TimeSpan timeout, IProgress<string> progress,
-            IEnumerable<string> tests);
+            IEnumerable<string> tests, IList<MutationVariant> mutationVariants);
 
         /// <summary>
         ///     Run the code coverage process.

--- a/Faultify.TestRunner/TestRun/DefaultMutationTestRun.cs
+++ b/Faultify.TestRunner/TestRun/DefaultMutationTestRun.cs
@@ -35,7 +35,7 @@ namespace Faultify.TestRunner.TestRun
                 timeout, logger);
 
             var testResults =
-                await testRunner.RunTests(timeout, sessionProgressTracker, runningTests);
+                await testRunner.RunTests(timeout, sessionProgressTracker, runningTests, _mutationVariants);
 
             ResetMutations(testProject);
 


### PR DESCRIPTION
Added a check that filters out unnecessary tests for the same mutations. 

Tests that will reach a time-out will be removed